### PR TITLE
[TH2-5102] Add operation timestamp property to message's metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ spec:
 
 # Changelog
 
+## 3.2.2
+
+* Add `th2.operation_timestamp` property to a message.
+  It contains the send/receive operation timestamp in ISO format: `2023-10-16T09:21:12.178299Z`
+
 ## 3.2.1
 * Avoid messages loss in case of failures while saving mangler events.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 kotlin_version=1.8.22
-release_version=3.2.1
+release_version=3.2.2
 description='Core library for dirty-TCP connections'
 vcs_url=https://github.com/th2-net/th2-conn-dirty-tcp-core
 

--- a/src/main/kotlin/com/exactpro/th2/conn/dirty/tcp/core/api/IChannel.kt
+++ b/src/main/kotlin/com/exactpro/th2/conn/dirty/tcp/core/api/IChannel.kt
@@ -137,4 +137,11 @@ interface IChannel {
          */
         DIRECT(false, false)
     }
+
+    companion object {
+        /**
+         * Property with the timestamp when bytes were actually send/received to/from tcp channel.
+         */
+        const val OPERATION_TIMESTAMP_PROPERTY: String = "th2.operation_timestamp"
+    }
 }

--- a/src/main/kotlin/com/exactpro/th2/conn/dirty/tcp/core/netty/ITcpChannelHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/conn/dirty/tcp/core/netty/ITcpChannelHandler.kt
@@ -17,11 +17,17 @@
 package com.exactpro.th2.conn.dirty.tcp.core.netty
 
 import io.netty.buffer.ByteBuf
+import java.time.Instant
 
 interface ITcpChannelHandler {
     fun onOpen()
     fun onReceive(buffer: ByteBuf): ByteBuf?
-    fun onMessage(message: ByteBuf)
+
+    /**
+     * Will be invoked on the [message] read from the channel using [onReceive] method.
+     * The [receiveTimestamp] will contain the timestamp when the bytes were received by channel.
+     */
+    fun onMessage(message: ByteBuf, receiveTimestamp: Instant)
     fun onError(cause: Throwable)
     fun onClose()
 }

--- a/src/main/kotlin/com/exactpro/th2/conn/dirty/tcp/core/netty/handlers/MainHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/conn/dirty/tcp/core/netty/handlers/MainHandler.kt
@@ -44,9 +44,9 @@ class MainHandler(
     }
 
     override fun decode(ctx: ChannelHandlerContext, buf: ByteBuf, out: MutableList<Any>) {
+        val receiveTime = Instant.now()
         logger.trace { "Attempting to decode data received from: ${ctx.channel().remoteAddress()} (data: ${hexDump(buf)})" }
 
-        val receiveTime = Instant.now()
         while (buf.isReadable) {
             val message = buf.readMessage(ctx) ?: break
 


### PR DESCRIPTION
Property `th2.operation_timestamp` is added to message's metadata with the value that corresponds to the actual operation timestamp (when the message was send/received)